### PR TITLE
Fix wrong column name

### DIFF
--- a/answer_sets_tbl/65.tbl
+++ b/answer_sets_tbl/65.tbl
@@ -1,4 +1,4 @@
-s_store_name|i_item_desc|revenue|i_current_price|i_wholesale_cost| i_brand
+s_store_name|i_item_desc|revenue|i_current_price|i_wholesale_cost|i_brand
 string_null|string_null|double_null|float_null|float_null|string_null
 able|Commercial, popular processes give later now wooden facts. Black, outer purposes examine national, precise heels. Invisible times s|36.06|5.25|1.68|amalgedu pack #1
 able|Conventional, responsible products discuss delicately then actual findings. Extremel|36.42|3.67|2.82|namelessnameless #5


### PR DESCRIPTION
`i_brand` contained a trailing space which lead to a failing verification.